### PR TITLE
v0.3.6 - Field Rules Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ import {
   StringArrayFilter,
   IntFieldFilter,
   FilterConfig,
-} from '@the-devoyage/mongo-filter-generator';
+} from "@the-devoyage/mongo-filter-generator";
 
 export interface GetDogsRequestBody {
   _id?: StringFieldFilter;
@@ -138,10 +138,10 @@ const GET_ACCOUNTS = gql`
 const { data } = useQuery(GET_ACCOUNTS, {
   variables: {
     getAccountsInput: {
-      email: { filterBy: 'REGEX', string: 'nick', operator: 'AND' },
+      email: { filterBy: "REGEX", string: "nick", operator: "AND" },
       role: [
-        { filterBy: 'EQ', int: 5, operator: 'OR' },
-        { filterBy: 'LT', int: 2, operator: 'OR' },
+        { filterBy: "EQ", int: 5, operator: "OR" },
+        { filterBy: "LT", int: 2, operator: "OR" },
       ],
     },
   },
@@ -151,13 +151,13 @@ const { data } = useQuery(GET_ACCOUNTS, {
 REST Example
 
 ```ts
-const response = await fetch('/api/accounts', {
-  method: 'GET',
+const response = await fetch("/api/accounts", {
+  method: "GET",
   body: JSON.stringify({
-    email: { filterBy: 'REGEX', string: 'nick', operator: 'AND' },
+    email: { filterBy: "REGEX", string: "nick", operator: "AND" },
     role: [
-      { filterBy: 'EQ', int: 5, operator: 'OR' },
-      { filterBy: 'LT', int: 2, operator: 'OR' },
+      { filterBy: "EQ", int: 5, operator: "OR" },
+      { filterBy: "LT", int: 2, operator: "OR" },
     ],
   }),
 });
@@ -172,7 +172,7 @@ GraphQL:
 First, add the MFG `typeDefs` and `resolvers` to the schema. Doing so allows you to use `FieldFilter`, `FilterConfig`, and `Stats` (along with other provided types, see reference for more) within a custom schema. It also provides the `ObjectID` and `DateTime` scalars to all of your current typeDefs.
 
 ```ts
-import { GraphQL } from '@the-devoyage/mongo-filter-generator';
+import { GraphQL } from "@the-devoyage/mongo-filter-generator";
 
 const schema = buildFederatedSchema([
   { typeDefs: GraphQL.typeDefs, resolvers: GraphQL.resolvers },
@@ -195,7 +195,7 @@ GraphQL Example
 Add Field Filters as Input Property Types
 
 ```ts
-import { gql } from 'apollo-server-core';
+import { gql } from "apollo-server-core";
 
 export const typeDefs = gql`
   type Account {
@@ -250,7 +250,7 @@ import {
   StringArrayFieldFilter,
   IntFieldFilter,
   FilterConfig,
-} from '@the-devoyage/mongo-filter-generator';
+} from "@the-devoyage/mongo-filter-generator";
 
 export interface GetDogsRequestBody {
   _id?: StringFieldFilter;
@@ -273,8 +273,8 @@ Graphql Example:
 
 ```ts
 // Resolvers.ts
-import { GenerateMongo } from '@the-devoyage/mongo-filter-generator';
-import { Account } from 'models';
+import { GenerateMongo } from "@the-devoyage/mongo-filter-generator";
+import { Account } from "models";
 
 export const Query: QueryResolvers = {
   getAccounts: async (_, args) => {
@@ -297,7 +297,7 @@ import {
   StringArrayFieldFilter,
   IntFieldFilter,
   FilterConfig,
-} from '@the-devoyage/mongo-filter-generator';
+} from "@the-devoyage/mongo-filter-generator";
 
 export interface GetDogsRequestBody {
   _id?: StringFieldFilter;
@@ -309,7 +309,7 @@ export interface GetDogsRequestBody {
   config?: FilterConfig;
 }
 
-app.get('/', (req, res) => {
+app.get("/", (req, res) => {
   const request: GetDogsRequestBody = req.body;
 
   const { filter, options } = GenerateMongo<IDog>({
@@ -329,8 +329,8 @@ app.get('/', (req, res) => {
 Use the generated `filter` and `options`, from the `GenerateMongo` method, with the provided find and paginate function.
 
 ```ts
-import { GenerateMongo } from '@the-devoyage/mongo-filter-generator';
-import { Account } from 'models';
+import { GenerateMongo } from "@the-devoyage/mongo-filter-generator";
+import { Account } from "models";
 
 export const Query: QueryResolvers = {
   getAccounts: async (_, args) => {
@@ -354,8 +354,8 @@ or
 **Note - You must Enable the `findAndPaginate()` method with Mongoose Plugins for the following to execute. Instructions below.**
 
 ```ts
-import { GenerateMongo } from '@the-devoyage/mongo-filter-generator';
-import { Account } from 'models';
+import { GenerateMongo } from "@the-devoyage/mongo-filter-generator";
+import { Account } from "models";
 
 export const Query: QueryResolvers = {
   getAccounts: async (_, args) => {
@@ -379,19 +379,19 @@ Note - If this is done within the server/entry point, the plugin must be defined
 
 ```ts
 // entry-point.ts
-import mongoose from 'mongoose';
-import { findAndPaginatePlugin } from '@the-devoyage/mongo-filter-generator';
+import mongoose from "mongoose";
+import { findAndPaginatePlugin } from "@the-devoyage/mongo-filter-generator";
 mongoose.plugin(findAndPaginatePlugin);
-import { typeDefs, resolvers } from './schema';
+import { typeDefs, resolvers } from "./schema";
 ```
 
 Lastly, if you are using typescript, be sure to provide the `FindAndPaginateModel` definition to the model. This informs Typescript that the method is available.
 
 ```ts
 // UserModel.ts
-import { FindAndPaginateModel } from '@the-devoyage/mongo-filter-generator';
-import mongoose from 'mongoose';
-import { User as IUser } from 'types/generated';
+import { FindAndPaginateModel } from "@the-devoyage/mongo-filter-generator";
+import mongoose from "mongoose";
+import { User as IUser } from "types/generated";
 
 const Schema = mongoose.Schema;
 
@@ -405,7 +405,7 @@ const UserSchema = new Schema<IUser, FindAndPaginateModel>(
 );
 
 export const User = mongoose.model<IUser, FindAndPaginateModel>(
-  'User',
+  "User",
   UserSchema
 );
 ```
@@ -502,6 +502,39 @@ type User {
 }
 ```
 
+### 6. Field Rules
+
+Server side, Field Rules can be applied to `GenerateMongo` arguments in order to perform a variety of actions when creating filters.
+
+Actions:
+
+- "INITIAL" - Provide a default field filter for every operation. Client request may overwrite the filter with their own request.
+- "DISABLE" - Revoke client permission to query certain fields. If the client request includes field filters for the disabled field, an error will be thrown.
+- "COMBINE" - Combine the field filter provided within the field rule with the client's field filter.
+- "OVERRIDE" - A default value that can not be overridden. An error is thrown if a client tries to request filtering with this field.
+
+```ts
+const { filter, options } =
+  GenerateMongo <
+  IUser >
+  {
+    fieldFilters: args.getAllUsersInput,
+    config: args.getAllUsersInput.config,
+    fieldRules: [
+      {
+        location: "name",
+        fieldFilter: {
+          string: "Edmo",
+          filterBy: "REGEX",
+          operator: "OR",
+          groups: ["names.and"],
+        },
+        action: "COMBINE",
+      },
+    ],
+  };
+```
+
 ## Reference
 
 ### Field Filters
@@ -510,27 +543,27 @@ Used to type the properties of an incoming request.
 
 ```ts
 type IntFieldFilter = {
-  filterBy: 'EQ' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'NE';
+  filterBy: "EQ" | "GT" | "GTE" | "LT" | "LTE" | "NE";
   int: number;
-  operator?: 'AND' | 'OR';
+  operator?: "AND" | "OR";
   groups: string[];
 };
 ```
 
 ```ts
 type StringFieldFilter = {
-  filterBy: 'MATCH' | 'REGEX' | 'OBJECTID';
+  filterBy: "MATCH" | "REGEX" | "OBJECTID";
   string: string;
-  operator?: 'AND' | 'OR';
+  operator?: "AND" | "OR";
   groups: string[];
 };
 ```
 
 ```ts
 type BooleanFieldFilter = {
-  filterBy: 'EQ' | 'NE';
+  filterBy: "EQ" | "NE";
   bool: Boolean;
-  operator?: 'AND' | 'OR';
+  operator?: "AND" | "OR";
   groups: string[];
 };
 ```
@@ -538,18 +571,18 @@ type BooleanFieldFilter = {
 ```ts
 type DateFieldFilter = {
   date: Date;
-  filterBy: 'EQ' | 'NE' | 'LT' | 'GT' | 'LTE' | 'GTE';
-  operator?: 'AND' | 'OR';
+  filterBy: "EQ" | "NE" | "LT" | "GT" | "LTE" | "GTE";
+  operator?: "AND" | "OR";
   groups: string[];
 };
 ```
 
 ```ts
 type StringArrayFieldFilter = {
-  filterBy: 'MATCH' | 'REGEX' | 'OBJECTID';
+  filterBy: "MATCH" | "REGEX" | "OBJECTID";
   string: string[];
-  arrayOptions: 'IN' | 'NIN';
-  operator?: 'AND' | 'OR';
+  arrayOptions: "IN" | "NIN";
+  operator?: "AND" | "OR";
   groups: string[];
 };
 ```
@@ -615,7 +648,7 @@ export interface PaginatedResponse<ModelType> {
 Resolvers and Type Defs that must be added to the graphql schema in order to use the available field filters, types, and scalars.
 
 ```ts
-import { GraphQL } from '@the-devoyage/mongo-filter-generator';
+import { GraphQL } from "@the-devoyage/mongo-filter-generator";
 
 const schema = buildFederatedSchema([
   { typeDefs: GraphQL.typeDefs, resolvers: GraphQL.resolvers },
@@ -642,8 +675,9 @@ A collection of helpers to validate field filters and other MFG objects.
 
 A collection of helpers to modify objects associated with MFG.
 
-- `Modify.addFilter` - Add a mongo query filter to an existing query filter object based on location, operator, groups, and array options.
+- `Modify.Filter.addFilter` - Add a mongo query filter to an existing query filter object based on location, operator, groups, and array options.
+- `Modify.FieldFilter.applyFieldRule` - Applies field rule to field filter and returns updated field filter if rule applies. Updated field rules array is returned based on the rule type as well.
 
-### Generate 
+### Generate
 
 - `Generate.filterQuery` - Converts any field filter to a Mongo Query Filter. Applies additional rules if applicable.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.5",
+  "version": "0.3.6",
   "name": "@the-devoyage/mongo-filter-generator",
   "author": "Nick",
   "license": "MIT",
@@ -15,12 +15,6 @@
   "scripts": {
     "start": "tsc -w && tsc-alias -w",
     "build": "tsc && tsc-alias"
-  },
-  "prettier": {
-    "printWidth": 80,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5"
   },
   "devDependencies": {
     "eslint": "^8.10.0",

--- a/src/generate-mongo/generate/generate.ts
+++ b/src/generate-mongo/generate/generate.ts
@@ -3,23 +3,10 @@ import { FilterQuery, isValidObjectId } from 'mongoose';
 import { GenerateFilterArguments } from '../../types';
 import mongoose from 'mongoose';
 
-export const filterQuery = <Arg>(
+export const filterQuery = (
   params: GenerateFilterArguments
 ): FilterQuery<unknown> | undefined => {
-  const { fieldRule } = params;
-  let { fieldFilter, location } = params;
-
-  if (fieldRule) {
-    if (fieldRule) {
-      if (fieldRule.disabled && Object.keys(fieldFilter ?? {}).length) {
-        throw new Error(`MFG ERROR: Access to property "${location}" denied.`);
-      }
-      if (fieldRule.fieldFilter) {
-        fieldFilter = fieldRule.fieldFilter;
-        location = fieldRule.location as Extract<keyof Arg, string>;
-      }
-    }
-  }
+  let { fieldFilter } = params;
 
   // Convert to Mongo Filters
   if (Validate.isStringFieldFilter(fieldFilter)) {
@@ -153,3 +140,4 @@ export const filterQuery = <Arg>(
     return;
   }
 };
+

--- a/src/generate-mongo/modify/modify.ts
+++ b/src/generate-mongo/modify/modify.ts
@@ -1,35 +1,33 @@
-import { AddFilterArguments } from '../../types';
-import { FilterQuery } from 'mongoose';
+import {
+  AddFilterArguments,
+  FieldFilter as IFieldFilter,
+  FieldRule,
+} from "../../types";
+import { FilterQuery } from "mongoose";
 
 const addFilter = (params: AddFilterArguments): FilterQuery<unknown> => {
-  const {
-    filter,
-    location,
-    newFilter,
-    operator,
-    arrayOptions,
-    groups,
-  } = params;
-  const parsedOperator = `$${operator ? operator.toLowerCase() : 'or'}`;
+  const { filter, location, newFilter, operator, arrayOptions, groups } =
+    params;
+  const parsedOperator = `$${operator ? operator.toLowerCase() : "or"}`;
 
   if (!arrayOptions) {
     if (groups) {
       for (const group of groups) {
-        const operatorType = group.includes('.or')
-          ? '$or'
-          : group.includes('.and')
-          ? '$and'
+        const operatorType = group.includes(".or")
+          ? "$or"
+          : group.includes(".and")
+          ? "$and"
           : null;
 
         if (!operatorType) {
           throw Error(
-            'Group names must contain `.and` or `.or` in order to categorize the filter type and function.'
+            "Group names must contain `.and` or `.or` in order to categorize the filter type and function."
           );
         }
 
         if (filter[operatorType]) {
           const updating = filter[operatorType]?.find(
-            existing => existing.group === group
+            (existing) => existing.group === group
           );
 
           if (updating) {
@@ -66,21 +64,21 @@ const addFilter = (params: AddFilterArguments): FilterQuery<unknown> => {
   } else {
     if (groups) {
       for (const group of groups) {
-        const operatorType = group.includes('.or')
-          ? '$or'
-          : group.includes('.and')
-          ? '$and'
+        const operatorType = group.includes(".or")
+          ? "$or"
+          : group.includes(".and")
+          ? "$and"
           : null;
 
         if (!operatorType) {
           throw Error(
-            'Group names must contain `.and` or `.or` in order to categorize the filter type and function.'
+            "Group names must contain `.and` or `.or` in order to categorize the filter type and function."
           );
         }
 
         if (filter[operatorType]) {
           const updating = filter[operatorType]?.find(
-            existing => existing.group === group
+            (existing) => existing.group === group
           );
 
           if (updating) {
@@ -135,6 +133,95 @@ const addFilter = (params: AddFilterArguments): FilterQuery<unknown> => {
   }
 
   return filter;
+};
+
+const applyFieldRule = (
+  fieldRule: FieldRule,
+  fieldFilter: IFieldFilter,
+  fieldRules: FieldRule[]
+): {
+  fieldFilter: IFieldFilter;
+  location: string;
+  updatedFieldRules: FieldRule[];
+} => {
+  switch (fieldRule.action) {
+    case "DISABLE":
+      if (fieldFilter) {
+        throw new Error(
+          `MFG ERROR: Access to property "${fieldRule.location}" denied by server.`
+        );
+      }
+      break;
+
+    case "COMBINE":
+      if (!fieldRule.fieldFilter?.groups?.length) {
+        throw new Error(
+          `MFG ERROR: Use of field rule action "COMBINE" requires at least one group to be present.`
+        );
+      }
+
+      if (fieldFilter) {
+        return {
+          fieldFilter: {
+            ...fieldFilter,
+            groups: [
+              ...(fieldFilter.groups ?? []),
+              ...(fieldRule.fieldFilter?.groups ?? []),
+            ],
+          },
+          location: fieldRule.location,
+          updatedFieldRules: fieldRules,
+        };
+      }
+      break;
+
+    case "INITIAL":
+      if (fieldFilter) {
+        fieldRules = fieldRules.filter(
+          (rule) => rule.location !== fieldRule.location
+        );
+        return {
+          fieldFilter: fieldFilter,
+          location: fieldRule.location,
+          updatedFieldRules: fieldRules,
+        };
+      }
+      break;
+
+    case "OVERRIDE":
+
+    default:
+      if (fieldFilter) {
+        throw new Error(
+          `MFG ERROR: Access to property "${fieldRule.location}" denied. Override value has been defined by server.`
+        );
+      }
+
+      if (!fieldRule.fieldFilter) {
+        throw new Error(
+          `MFG ERROR: Access to property "${fieldRule.location}" denied. Override value has not been specified by server.`
+        );
+      }
+
+      fieldRules = fieldRules.filter(
+        (rule) => rule.location !== fieldRule.location
+      );
+      return {
+        fieldFilter: fieldRule.fieldFilter,
+        location: fieldRule.location,
+        updatedFieldRules: fieldRules,
+      };
+  }
+
+  return {
+    fieldFilter,
+    updatedFieldRules: fieldRules,
+    location: fieldRule.location,
+  };
+};
+
+export const FieldFilter = {
+  applyFieldRule,
 };
 
 export const Filter = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export type Pagination = {
 export interface FieldRule {
   location: string;
   fieldFilter?: FieldFilter;
-  disabled?: boolean;
+  action: "DISABLE" | "OVERRIDE" | "COMBINE" | "INITIAL"
 }
 
 // Filters
@@ -91,8 +91,6 @@ export interface GenerateMongoArguments<DocumentType> {
 
 export interface GenerateFilterArguments {
   fieldFilter?: FieldFilter;
-  location: string;
-  fieldRule?: FieldRule;
 }
 
 export interface FindWithPaginationParams<ModelType> {


### PR DESCRIPTION
Field Rules have been updated and refactored in order to fix issues dealing with duplicate queries between clients and server (field rules). 

In addition to being able to disable a field that is being queried, three new actions have been updated including the ability to "COMBINE" field rules with client queries, "OVERRIDE" client queries, and "INITIAL" queries that clients can override.

closes #1 